### PR TITLE
Docker multistage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8 as builder
+FROM node:8-alpine as builder
 
 RUN mkdir /runtime
 COPY wallboard-app /runtime/
@@ -9,9 +9,9 @@ RUN npm run build --prod
 #RUN cp -pr /runtime/dist/* /usr/local/apache2/htdocs/
 
 
-FROM httpd:2.4
+FROM httpd:2.4-alpine
 COPY apache-httpd/httpd.conf /usr/local/apache2/conf/httpd.conf
 
-COPY --from=builder /runtime/dist/* /usr/local/apache2/htdocs/
+COPY --from=builder /runtime/dist /usr/local/apache2/htdocs/
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-FROM httpd:2.4
-
-RUN apt-get update
-RUN apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get install -y nodejs
-
-COPY apache-httpd/httpd.conf /usr/local/apache2/conf/httpd.conf
+FROM node:8 as builder
 
 RUN mkdir /runtime
 COPY wallboard-app /runtime/
@@ -13,6 +6,12 @@ WORKDIR /runtime
 
 RUN npm install
 RUN npm run build --prod
-RUN cp -pr /runtime/dist/* /usr/local/apache2/htdocs/
+#RUN cp -pr /runtime/dist/* /usr/local/apache2/htdocs/
+
+
+FROM httpd:2.4
+COPY apache-httpd/httpd.conf /usr/local/apache2/conf/httpd.conf
+
+COPY --from=builder /runtime/dist/* /usr/local/apache2/htdocs/
 
 EXPOSE 80


### PR DESCRIPTION
Afin d'accélérer le build (du moins la première fois) et réduire l'image finale, j'ai modifié ton Dockerfile pour utiliser le multi-stage build.
Et je suis passé sur alpine (qui est plus petit, et donc le download des images de base est plus rapide)

**Avant:** 
First Build time : 3 min 38
Size : 691MB

**Après:**
First Build Time : 1 min 49
Size : 87.9MB